### PR TITLE
CP-32123: Integrate blktap with CCM openssl 1.1.1

### DIFF
--- a/drivers/block-crypto.h
+++ b/drivers/block-crypto.h
@@ -32,5 +32,6 @@
 
 
 int vhd_open_crypto(vhd_context_t *vhd, struct td_vbd_encryption *encryption, const char *name);
+void vhd_close_crypto(vhd_context_t *vhd);
 void vhd_crypto_encrypt(vhd_context_t *vhd, td_request_t *t, char *orig_buf);
 void vhd_crypto_decrypt(vhd_context_t *vhd, td_request_t *t);

--- a/drivers/crypto/compat-crypto-openssl.h
+++ b/drivers/crypto/compat-crypto-openssl.h
@@ -9,8 +9,8 @@
 
 struct crypto_blkcipher
 {
-	EVP_CIPHER_CTX de_ctx;
-	EVP_CIPHER_CTX en_ctx;
+	EVP_CIPHER_CTX *de_ctx;
+	EVP_CIPHER_CTX *en_ctx;
 };
 
 #endif

--- a/drivers/crypto/xts_aes.h
+++ b/drivers/crypto/xts_aes.h
@@ -52,9 +52,9 @@ xts_aes_plain_encrypt(struct crypto_blkcipher *xts_tfm, sector_t sector,
 	int dstlen;
 	xts_aes_plain_iv_generate(iv, 16, sector);
 
-	if (!EVP_CipherInit_ex(&xts_tfm->en_ctx, NULL, NULL, NULL, iv, -1))
+	if (!EVP_CipherInit_ex(xts_tfm->en_ctx, NULL, NULL, NULL, iv, -1))
 		return -1;
-	if (!EVP_CipherUpdate(&xts_tfm->en_ctx, dst_buf, &dstlen, src_buf, nbytes))
+	if (!EVP_CipherUpdate(xts_tfm->en_ctx, dst_buf, &dstlen, src_buf, nbytes))
 		return -2;
 	/* no need to finalize with XTS when multiple of blocksize */
 	return 0;
@@ -68,9 +68,9 @@ xts_aes_plain_decrypt(struct crypto_blkcipher *xts_tfm, sector_t sector,
 	int dstlen;
 	xts_aes_plain_iv_generate(iv, 16, sector);
 
-	if (!EVP_CipherInit_ex(&xts_tfm->de_ctx, NULL, NULL, NULL, iv, -1))
+	if (!EVP_CipherInit_ex(xts_tfm->de_ctx, NULL, NULL, NULL, iv, -1))
 		return -1;
-	if (!EVP_CipherUpdate(&xts_tfm->de_ctx, dst_buf, &dstlen, src_buf, nbytes))
+	if (!EVP_CipherUpdate(xts_tfm->de_ctx, dst_buf, &dstlen, src_buf, nbytes))
 		return -2;
 	/* no need to finalize with XTS when multiple of blocksize */
 	return 0;


### PR DESCRIPTION
This patch needs to be merged with blktap.spec together as CCM openssl
1.1.1 is required when building this package

Signed-off-by: Qin Zhang <qin.zhang@citrix.com>